### PR TITLE
[SWARM-2564] Fix Mssql timezone handling

### DIFF
--- a/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.js
+++ b/packages/cubejs-schema-compiler/src/adapter/MssqlQuery.js
@@ -54,7 +54,8 @@ export class MssqlQuery extends BaseQuery {
   }
 
   convertTz(field) {
-    return `TODATETIMEOFFSET(${field}, '${moment().tz(this.timezone).format('Z')}')`;
+    // as the offset is ignored for some stuff (e.g. DATEDIFF) we convert timestamp to requested timezone directly
+    return `CAST(SWITCHOFFSET(${field}, '${moment().tz(this.timezone).format('Z')}')as datetime2)`;
   }
 
   timeStampCast(value) {


### PR DESCRIPTION
Stuff for testing local:

- change SQL query for crossingline cube to: 
```
SELECT * FROM ( VALUES ( CAST (N'2022-09-25 06:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 07:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 08:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 10:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 11:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 12:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 13:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-18 07:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-18 08:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-18 10:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-18 11:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-18 12:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-18 13:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null),
(CAST (N'2022-09-25 09:00:43.6182540' as datetime2), N'Tobias Nano - Do not touch!', N'411377e7-d823-4106-8e1a-6028fa1353ce', N'Villach Bicycle Counting', N'047e2e23-f318-4bed-afa4-5e54c6c3d63c', N'bicycle', null, N'in', N'cl1', N'41236cd5-8347-4c08-86f8-d1efefe99c8b', 5, null)) 
as temp(timestamp, nodeName, nodeId, streamName, streamId, class, subclass, direction, lineName, lineId, speedEstimate, numberPlateOrigin)
```

- after starting up swarm-cube-api dev env with this new changes open in browser http://localhost:4000/#/build?query={%22measures%22:[%22CrossingEvents.count%22],%22timeDimensions%22:[{%22dimension%22:%22CrossingEvents.timestamp%22,%22granularity%22:%22hour%22,%22dateRange%22:[%222022-09-19%22,%222022-09-25%22]}],%22order%22:{%22CrossingEvents.timestamp%22:%22asc%22},%22timezone%22:%22Asia/Anadyr%22} for query with timezone set to "Asia/Anadyr" (UTC+12)

- results show that timestamps are returned converted and by inspecting network-response it can be seen that all timestamps that are out of  requested scope for timezone Asia/Anadyr are not returned